### PR TITLE
Fix: Close Socket.IO connection on beforeunload event

### DIFF
--- a/html/static/scripts/chat.js
+++ b/html/static/scripts/chat.js
@@ -536,5 +536,13 @@ var Chat = {
 				reader.readAsDataURL(file);
 			}
 		});
+
+		// close socket upon refresh or tab close, free the username
+		window.addEventListener("beforeunload", () => {
+			if(!Chat.is_online){
+				return;
+			}
+			Chat.socket.disconnect();
+		});
 	}
 };


### PR DESCRIPTION
This fixes the case where a user may refresh the page and cannot use their saved nick.