### PR TITLE
Fix: messages on wrong side when username has trailing whitespace

### DIFF
--- a/html/static/scripts/chat.js
+++ b/html/static/scripts/chat.js
@@ -341,7 +341,7 @@ var Chat = {
 			alert(fail);
 		}
 
-		var nick = prompt("Your nick:", sessionStorage.nick || localStorage.nick || "");
+		var nick = prompt("Your nick:", sessionStorage.nick || localStorage.nick || "").trim();
 		if(typeof nick !== "undefined" && nick){
 			sessionStorage.nick = localStorage.nick = nick;
 			Chat.socket.emit("login", {


### PR DESCRIPTION
autocomplete behavior on mobile devices can cause some trailing whitespace which causes own sent messages to appear on wrong side. also prevents the possibility of "username" and "username "